### PR TITLE
Update database Docker images

### DIFF
--- a/stubs/services/mysql.stub
+++ b/stubs/services/mysql.stub
@@ -1,5 +1,5 @@
   mysql:
-    image: 'mysql/mysql-server:8.0'
+    image: 'mysql:8.4'
     ports:
       - '${MYSQL_PORT:-3306}:3306'
     environment:

--- a/stubs/services/pgsql.stub
+++ b/stubs/services/pgsql.stub
@@ -1,5 +1,5 @@
   pgsql:
-    image: 'postgres:18'
+    image: 'postgres:18-alpine'
     ports:
       - '${PG_PORT:-5432}:5432'
     environment:

--- a/stubs/services/pgsql.stub
+++ b/stubs/services/pgsql.stub
@@ -1,5 +1,5 @@
   pgsql:
-    image: 'postgres:15'
+    image: 'postgres:18'
     ports:
       - '${PG_PORT:-5432}:5432'
     environment:


### PR DESCRIPTION
- **Mysql**: update to version `8.4` using official `mysql:8.4` image instead of  `mysql/mysql-server:8.0`
- **Postgres**: update to version `18` using `alpine`. I think that a smaller image could be beneficial for local development